### PR TITLE
Support lightweight tags in git supplier

### DIFF
--- a/reckon-core/src/main/groovy/org/ajoberstar/reckon/core/git/GitInventorySupplier.java
+++ b/reckon-core/src/main/groovy/org/ajoberstar/reckon/core/git/GitInventorySupplier.java
@@ -128,7 +128,9 @@ public final class GitInventorySupplier implements VcsInventorySupplier {
 
     for (Ref ref : repo.getRefDatabase().getRefs(Constants.R_TAGS).values()) {
       Ref tag = repo.peel(ref);
-      ObjectId objectId = tag.getPeeledObjectId();
+      // only annotated tags return a peeled object id
+      ObjectId objectId =
+          tag.getPeeledObjectId() == null ? tag.getObjectId() : tag.getPeeledObjectId();
       RevCommit commit = walk.parseCommit(objectId);
       tagParser
           .apply(tag)

--- a/reckon-core/src/test/groovy/org/ajoberstar/reckon/core/git/GitInventorySupplierTest.groovy
+++ b/reckon-core/src/test/groovy/org/ajoberstar/reckon/core/git/GitInventorySupplierTest.groovy
@@ -200,7 +200,7 @@ class GitInventorySupplierTest extends Specification {
     commit()
     branch('parallel-untagged-since-merge')
     commit()
-    tag('0.3.0-milestone.1')
+    tag('0.3.0-milestone.1', false)
     commit()
     branch('parallel-tagged-since-merge')
     commit()
@@ -264,9 +264,9 @@ class GitInventorySupplierTest extends Specification {
     assert currentHead == atCommit
   }
 
-  private void tag(String name) {
+  private void tag(String name, boolean annotate = true) {
     def currentHead = grgit.head()
-    def newTag = grgit.tag.add(name: name)
+    def newTag = grgit.tag.add(name: name, annotate: annotate)
     def atCommit = grgit.resolve.toCommit(newTag.fullName)
     println "Added new tag ${name} at ${atCommit.abbreviatedId}"
     assert currentHead == atCommit


### PR DESCRIPTION
Lightweight tags don't have a peeled object id.