### PR TITLE
Rebuilds should not be treated as claimed versions

### DIFF
--- a/reckon-core/src/main/java/org/ajoberstar/reckon/core/Reckoner.java
+++ b/reckon-core/src/main/java/org/ajoberstar/reckon/core/Reckoner.java
@@ -40,7 +40,8 @@ public final class Reckoner {
                         && !Versions.isNormal(targetVersion))
             .orElse(targetVersion);
 
-    if (inventory.getClaimedVersions().contains(reckoned)) {
+    if (inventory.getClaimedVersions().contains(reckoned)
+        && !inventory.getCurrentVersion().map(reckoned::equals).orElse(false)) {
       throw new IllegalStateException(
           "Reckoned version " + reckoned + " has already been released.");
     }

--- a/reckon-core/src/test/groovy/org/ajoberstar/reckon/core/ReckonerTest.groovy
+++ b/reckon-core/src/test/groovy/org/ajoberstar/reckon/core/ReckonerTest.groovy
@@ -66,7 +66,7 @@ class ReckonerTest extends Specification {
         Version.valueOf('1.2.2'),
         1,
         [Version.valueOf('1.3.0')] as Set,
-        [Version.valueOf('2.0.0-rc.1')] as Set
+        [Version.valueOf('1.2.2'), Version.valueOf('1.2.3-milestone.1')] as Set
         )
     VcsInventorySupplier inventorySupplier2 = Mock()
     inventorySupplier2.getInventory() >> inventory2
@@ -85,7 +85,7 @@ class ReckonerTest extends Specification {
         Version.valueOf('1.2.2'),
         1,
         [Version.valueOf('1.3.0')] as Set,
-        [Version.valueOf('2.0.0-rc.2')] as Set
+        [Version.valueOf('1.2.2'), Version.valueOf('1.2.3-milestone.1'), Version.valueOf('2.0.0-milestone.1')] as Set
         )
     VcsInventorySupplier inventorySupplier2 = Mock()
     inventorySupplier2.getInventory() >> inventory2
@@ -104,7 +104,7 @@ class ReckonerTest extends Specification {
         Version.valueOf('1.2.2'),
         1,
         [Version.valueOf('1.3.0')] as Set,
-        [Version.valueOf('2.0.0-rc.2')] as Set
+        [Version.valueOf('1.2.2'), Version.valueOf('1.2.3-milestone.1')] as Set
         )
     VcsInventorySupplier inventorySupplier2 = Mock()
     inventorySupplier2.getInventory() >> inventory2


### PR DESCRIPTION
When doing a rebuild, you will obviously end up with a version included
in claimed. This should not be considered an issue. However, this does
mean that the Gradle plugin needs to make sure the tag doesn't already
exist before trying to tag it.

This resolves #47.