### PR TITLE
[WIP] Support JGit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,3 @@ allprojects {
   }
 
 }
-
-ext.grgitVersion = '[2.0.0,)'
-ext.jgitVersion = '[4.11.0,5.0)'

--- a/reckon-core/build.gradle
+++ b/reckon-core/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'groovy'
+  id 'java-library'
 }
 
 sourceCompatibility = 8
@@ -10,18 +11,18 @@ repositories {
 
 dependencies {
   // logging
-  compile 'org.slf4j:slf4j-api:[1.7.25,1.8.0-alpha)' // wait until final 1.8.0 is out to upgrade
-  testRuntime 'org.slf4j:slf4j-simple:[1.7.25,1.8.0-alpha)'
+  implementation 'org.slf4j:slf4j-api:[1.7.25,1.8.0-alpha)' // wait until final 1.8.0 is out to upgrade
+  testRuntimeOnly 'org.slf4j:slf4j-simple:[1.7.25,1.8.0-alpha)'
 
   // git
-  compile "org.eclipse.jgit:org.eclipse.jgit:$jgitVersion"
-  testCompile "org.ajoberstar:grgit:$grgitVersion"
+  api 'org.eclipse.jgit:org.eclipse.jgit:latest.release'
+  testImplementation 'org.ajoberstar:grgit:latest.release'
 
   // util
-  compile 'org.apache.commons:commons-lang3:[3.5,4.0)'
-  compile 'com.github.zafarkhaja:java-semver:[0.9.0,)'
+  implementation 'org.apache.commons:commons-lang3:latest.release'
+  implementation 'com.github.zafarkhaja:java-semver:latest.release'
 
   // testing
-  testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
-  testCompile 'org.codehaus.groovy:groovy-all:2.4.15'
+  testImplementation 'org.spockframework:spock-core:1.1-groovy-2.4'
+  testImplementation 'org.codehaus.groovy:groovy-all:2.4.15'
 }

--- a/reckon-core/gradle/dependency-locks/compile.lockfile
+++ b/reckon-core/gradle/dependency-locks/compile.lockfile
@@ -1,14 +1,3 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.zafarkhaja:java-semver:0.9.0
-com.googlecode.javaewah:JavaEWAH:1.1.6
-com.jcraft:jsch:0.1.54
-com.jcraft:jzlib:1.1.1
-commons-codec:commons-codec:1.9
-commons-logging:commons-logging:1.2
-org.apache.commons:commons-lang3:3.7
-org.apache.httpcomponents:httpclient:4.5.2
-org.apache.httpcomponents:httpcore:4.4.4
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
-org.slf4j:slf4j-api:1.7.25

--- a/reckon-core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/reckon-core/gradle/dependency-locks/compileClasspath.lockfile
@@ -10,5 +10,5 @@ commons-logging:commons-logging:1.2
 org.apache.commons:commons-lang3:3.7
 org.apache.httpcomponents:httpclient:4.5.2
 org.apache.httpcomponents:httpcore:4.4.4
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
+org.eclipse.jgit:org.eclipse.jgit:5.0.0.201805301535-rc2
 org.slf4j:slf4j-api:1.7.25

--- a/reckon-core/gradle/dependency-locks/default.lockfile
+++ b/reckon-core/gradle/dependency-locks/default.lockfile
@@ -10,5 +10,5 @@ commons-logging:commons-logging:1.2
 org.apache.commons:commons-lang3:3.7
 org.apache.httpcomponents:httpclient:4.5.2
 org.apache.httpcomponents:httpcore:4.4.4
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
+org.eclipse.jgit:org.eclipse.jgit:5.0.0.201805301535-rc2
 org.slf4j:slf4j-api:1.7.25

--- a/reckon-core/gradle/dependency-locks/runtime.lockfile
+++ b/reckon-core/gradle/dependency-locks/runtime.lockfile
@@ -1,14 +1,3 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.zafarkhaja:java-semver:0.9.0
-com.googlecode.javaewah:JavaEWAH:1.1.6
-com.jcraft:jsch:0.1.54
-com.jcraft:jzlib:1.1.1
-commons-codec:commons-codec:1.9
-commons-logging:commons-logging:1.2
-org.apache.commons:commons-lang3:3.7
-org.apache.httpcomponents:httpclient:4.5.2
-org.apache.httpcomponents:httpcore:4.4.4
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
-org.slf4j:slf4j-api:1.7.25

--- a/reckon-core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/reckon-core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -10,5 +10,5 @@ commons-logging:commons-logging:1.2
 org.apache.commons:commons-lang3:3.7
 org.apache.httpcomponents:httpclient:4.5.2
 org.apache.httpcomponents:httpcore:4.4.4
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
+org.eclipse.jgit:org.eclipse.jgit:5.0.0.201805301535-rc2
 org.slf4j:slf4j-api:1.7.25

--- a/reckon-core/gradle/dependency-locks/testCompile.lockfile
+++ b/reckon-core/gradle/dependency-locks/testCompile.lockfile
@@ -1,28 +1,3 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.zafarkhaja:java-semver:0.9.0
-com.googlecode.javaewah:JavaEWAH:1.1.6
-com.jcraft:jsch.agentproxy.core:0.0.9
-com.jcraft:jsch.agentproxy.jsch:0.0.9
-com.jcraft:jsch.agentproxy.pageant:0.0.9
-com.jcraft:jsch.agentproxy.sshagent:0.0.9
-com.jcraft:jsch.agentproxy.usocket-jna:0.0.9
-com.jcraft:jsch.agentproxy.usocket-nc:0.0.9
-com.jcraft:jsch:0.1.54
-com.jcraft:jzlib:1.1.1
-commons-codec:commons-codec:1.9
-commons-logging:commons-logging:1.2
-junit:junit:4.12
-net.java.dev.jna:jna-platform:4.1.0
-net.java.dev.jna:jna:4.1.0
-org.ajoberstar:grgit:2.2.1
-org.apache.commons:commons-lang3:3.7
-org.apache.httpcomponents:httpclient:4.5.2
-org.apache.httpcomponents:httpcore:4.4.4
-org.codehaus.groovy:groovy-all:2.4.15
-org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
-org.hamcrest:hamcrest-core:1.3
-org.slf4j:slf4j-api:1.7.25
-org.spockframework:spock-core:1.1-groovy-2.4

--- a/reckon-core/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/reckon-core/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -22,7 +22,7 @@ org.apache.httpcomponents:httpclient:4.5.2
 org.apache.httpcomponents:httpcore:4.4.4
 org.codehaus.groovy:groovy-all:2.4.15
 org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
+org.eclipse.jgit:org.eclipse.jgit:5.0.0.201805301535-rc2
 org.hamcrest:hamcrest-core:1.3
 org.slf4j:slf4j-api:1.7.25
 org.spockframework:spock-core:1.1-groovy-2.4

--- a/reckon-core/gradle/dependency-locks/testRuntime.lockfile
+++ b/reckon-core/gradle/dependency-locks/testRuntime.lockfile
@@ -1,29 +1,3 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.zafarkhaja:java-semver:0.9.0
-com.googlecode.javaewah:JavaEWAH:1.1.6
-com.jcraft:jsch.agentproxy.core:0.0.9
-com.jcraft:jsch.agentproxy.jsch:0.0.9
-com.jcraft:jsch.agentproxy.pageant:0.0.9
-com.jcraft:jsch.agentproxy.sshagent:0.0.9
-com.jcraft:jsch.agentproxy.usocket-jna:0.0.9
-com.jcraft:jsch.agentproxy.usocket-nc:0.0.9
-com.jcraft:jsch:0.1.54
-com.jcraft:jzlib:1.1.1
-commons-codec:commons-codec:1.9
-commons-logging:commons-logging:1.2
-junit:junit:4.12
-net.java.dev.jna:jna-platform:4.1.0
-net.java.dev.jna:jna:4.1.0
-org.ajoberstar:grgit:2.2.1
-org.apache.commons:commons-lang3:3.7
-org.apache.httpcomponents:httpclient:4.5.2
-org.apache.httpcomponents:httpcore:4.4.4
-org.codehaus.groovy:groovy-all:2.4.15
-org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
-org.hamcrest:hamcrest-core:1.3
-org.slf4j:slf4j-api:1.7.25
-org.slf4j:slf4j-simple:1.7.25
-org.spockframework:spock-core:1.1-groovy-2.4

--- a/reckon-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/reckon-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -22,7 +22,7 @@ org.apache.httpcomponents:httpclient:4.5.2
 org.apache.httpcomponents:httpcore:4.4.4
 org.codehaus.groovy:groovy-all:2.4.15
 org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
+org.eclipse.jgit:org.eclipse.jgit:5.0.0.201805301535-rc2
 org.hamcrest:hamcrest-core:1.3
 org.slf4j:slf4j-api:1.7.25
 org.slf4j:slf4j-simple:1.7.25

--- a/reckon-core/src/main/java/org/ajoberstar/reckon/core/GitInventorySupplier.java
+++ b/reckon-core/src/main/java/org/ajoberstar/reckon/core/GitInventorySupplier.java
@@ -120,8 +120,8 @@ final class GitInventorySupplier implements VcsInventorySupplier {
   private Set<TaggedVersion> getTaggedVersions(RevWalk walk) throws IOException {
     Set<TaggedVersion> versions = new HashSet<>();
 
-    for (Ref ref : repo.getRefDatabase().getRefs(Constants.R_TAGS).values()) {
-      Ref tag = repo.peel(ref);
+    for (Ref ref : repo.getRefDatabase().getRefsByPrefix(Constants.R_TAGS)) {
+      Ref tag = repo.getRefDatabase().peel(ref);
       // only annotated tags return a peeled object id
       ObjectId objectId = tag.getPeeledObjectId() == null ? tag.getObjectId() : tag.getPeeledObjectId();
       RevCommit commit = walk.parseCommit(objectId);

--- a/reckon-gradle/build.gradle
+++ b/reckon-gradle/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'groovy'
+  id 'java-library'
   id 'java-gradle-plugin'
 }
 
@@ -11,25 +12,25 @@ repositories {
 
 dependencies {
   // gradle
-  compile gradleApi()
+  api gradleApi()
 
   // reckon
-  compile project(':reckon-core')
+  api project(':reckon-core')
 
   // git
-  compile "org.eclipse.jgit:org.eclipse.jgit:$jgitVersion"
-  compile "org.ajoberstar:grgit:$grgitVersion"
-  compatTestCompile "org.ajoberstar:grgit:$grgitVersion"
+  implementation 'org.eclipse.jgit:org.eclipse.jgit:latest.release'
+  implementation 'org.ajoberstar:grgit:latest.release'
+  compatTestImplementation 'org.ajoberstar:grgit:latest.release'
 
   // util
-  compile 'com.google.guava:guava:[21.0,)'
-  compile 'com.github.zafarkhaja:java-semver:[0.9.0,)'
+  implementation 'com.google.guava:guava:[21.0,)'
+  implementation 'com.github.zafarkhaja:java-semver:[0.9.0,)'
 
   // testing
-  compatTestCompile gradleTestKit()
-  compatTestCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
-  compatTestCompile 'org.codehaus.groovy:groovy-all:2.4.15'
-  compatTestCompile 'junit:junit:4.12'
+  compatTestImplementation gradleTestKit()
+  compatTestImplementation 'org.spockframework:spock-core:1.1-groovy-2.4'
+  compatTestImplementation 'org.codehaus.groovy:groovy-all:2.4.15'
+  compatTestImplementation 'junit:junit:4.12'
 }
 
 stutter {

--- a/reckon-gradle/gradle/dependency-locks/compatTestCompile.lockfile
+++ b/reckon-gradle/gradle/dependency-locks/compatTestCompile.lockfile
@@ -1,25 +1,3 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.googlecode.javaewah:JavaEWAH:1.1.6
-com.jcraft:jsch.agentproxy.core:0.0.9
-com.jcraft:jsch.agentproxy.jsch:0.0.9
-com.jcraft:jsch.agentproxy.pageant:0.0.9
-com.jcraft:jsch.agentproxy.sshagent:0.0.9
-com.jcraft:jsch.agentproxy.usocket-jna:0.0.9
-com.jcraft:jsch.agentproxy.usocket-nc:0.0.9
-com.jcraft:jsch:0.1.54
-com.jcraft:jzlib:1.1.1
-commons-codec:commons-codec:1.9
-commons-logging:commons-logging:1.2
-junit:junit:4.12
-net.java.dev.jna:jna-platform:4.1.0
-net.java.dev.jna:jna:4.1.0
-org.ajoberstar:grgit:2.2.1
-org.apache.httpcomponents:httpclient:4.5.2
-org.apache.httpcomponents:httpcore:4.4.4
-org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
-org.hamcrest:hamcrest-core:1.3
-org.slf4j:slf4j-api:1.7.2
-org.spockframework:spock-core:1.1-groovy-2.4

--- a/reckon-gradle/gradle/dependency-locks/compatTestRuntime.lockfile
+++ b/reckon-gradle/gradle/dependency-locks/compatTestRuntime.lockfile
@@ -1,25 +1,3 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.googlecode.javaewah:JavaEWAH:1.1.6
-com.jcraft:jsch.agentproxy.core:0.0.9
-com.jcraft:jsch.agentproxy.jsch:0.0.9
-com.jcraft:jsch.agentproxy.pageant:0.0.9
-com.jcraft:jsch.agentproxy.sshagent:0.0.9
-com.jcraft:jsch.agentproxy.usocket-jna:0.0.9
-com.jcraft:jsch.agentproxy.usocket-nc:0.0.9
-com.jcraft:jsch:0.1.54
-com.jcraft:jzlib:1.1.1
-commons-codec:commons-codec:1.9
-commons-logging:commons-logging:1.2
-junit:junit:4.12
-net.java.dev.jna:jna-platform:4.1.0
-net.java.dev.jna:jna:4.1.0
-org.ajoberstar:grgit:2.2.1
-org.apache.httpcomponents:httpclient:4.5.2
-org.apache.httpcomponents:httpcore:4.4.4
-org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
-org.hamcrest:hamcrest-core:1.3
-org.slf4j:slf4j-api:1.7.2
-org.spockframework:spock-core:1.1-groovy-2.4

--- a/reckon-gradle/gradle/dependency-locks/compile.lockfile
+++ b/reckon-gradle/gradle/dependency-locks/compile.lockfile
@@ -1,30 +1,3 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.zafarkhaja:java-semver:0.9.0
-com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.1.3
-com.google.guava:guava:25.1-jre
-com.google.j2objc:j2objc-annotations:1.1
-com.googlecode.javaewah:JavaEWAH:1.1.6
-com.jcraft:jsch.agentproxy.core:0.0.9
-com.jcraft:jsch.agentproxy.jsch:0.0.9
-com.jcraft:jsch.agentproxy.pageant:0.0.9
-com.jcraft:jsch.agentproxy.sshagent:0.0.9
-com.jcraft:jsch.agentproxy.usocket-jna:0.0.9
-com.jcraft:jsch.agentproxy.usocket-nc:0.0.9
-com.jcraft:jsch:0.1.54
-com.jcraft:jzlib:1.1.1
-commons-codec:commons-codec:1.9
-commons-logging:commons-logging:1.2
-net.java.dev.jna:jna-platform:4.1.0
-net.java.dev.jna:jna:4.1.0
-org.ajoberstar:grgit:2.2.1
-org.apache.commons:commons-lang3:3.7
-org.apache.httpcomponents:httpclient:4.5.2
-org.apache.httpcomponents:httpcore:4.4.4
-org.checkerframework:checker-qual:2.0.0
-org.codehaus.mojo:animal-sniffer-annotations:1.14
-org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
-org.slf4j:slf4j-api:1.7.25

--- a/reckon-gradle/gradle/dependency-locks/compileClasspath.lockfile
+++ b/reckon-gradle/gradle/dependency-locks/compileClasspath.lockfile
@@ -20,11 +20,10 @@ commons-logging:commons-logging:1.2
 net.java.dev.jna:jna-platform:4.1.0
 net.java.dev.jna:jna:4.1.0
 org.ajoberstar:grgit:2.2.1
-org.apache.commons:commons-lang3:3.7
 org.apache.httpcomponents:httpclient:4.5.2
 org.apache.httpcomponents:httpcore:4.4.4
 org.checkerframework:checker-qual:2.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.14
 org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
-org.slf4j:slf4j-api:1.7.25
+org.eclipse.jgit:org.eclipse.jgit:5.0.0.201805301535-rc2
+org.slf4j:slf4j-api:1.7.2

--- a/reckon-gradle/gradle/dependency-locks/default.lockfile
+++ b/reckon-gradle/gradle/dependency-locks/default.lockfile
@@ -26,5 +26,5 @@ org.apache.httpcomponents:httpcore:4.4.4
 org.checkerframework:checker-qual:2.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.14
 org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
+org.eclipse.jgit:org.eclipse.jgit:5.0.0.201805301535-rc2
 org.slf4j:slf4j-api:1.7.25

--- a/reckon-gradle/gradle/dependency-locks/runtime.lockfile
+++ b/reckon-gradle/gradle/dependency-locks/runtime.lockfile
@@ -1,30 +1,3 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.zafarkhaja:java-semver:0.9.0
-com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.1.3
-com.google.guava:guava:25.1-jre
-com.google.j2objc:j2objc-annotations:1.1
-com.googlecode.javaewah:JavaEWAH:1.1.6
-com.jcraft:jsch.agentproxy.core:0.0.9
-com.jcraft:jsch.agentproxy.jsch:0.0.9
-com.jcraft:jsch.agentproxy.pageant:0.0.9
-com.jcraft:jsch.agentproxy.sshagent:0.0.9
-com.jcraft:jsch.agentproxy.usocket-jna:0.0.9
-com.jcraft:jsch.agentproxy.usocket-nc:0.0.9
-com.jcraft:jsch:0.1.54
-com.jcraft:jzlib:1.1.1
-commons-codec:commons-codec:1.9
-commons-logging:commons-logging:1.2
-net.java.dev.jna:jna-platform:4.1.0
-net.java.dev.jna:jna:4.1.0
-org.ajoberstar:grgit:2.2.1
-org.apache.commons:commons-lang3:3.7
-org.apache.httpcomponents:httpclient:4.5.2
-org.apache.httpcomponents:httpcore:4.4.4
-org.checkerframework:checker-qual:2.0.0
-org.codehaus.mojo:animal-sniffer-annotations:1.14
-org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
-org.slf4j:slf4j-api:1.7.25

--- a/reckon-gradle/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/reckon-gradle/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -26,5 +26,5 @@ org.apache.httpcomponents:httpcore:4.4.4
 org.checkerframework:checker-qual:2.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.14
 org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
+org.eclipse.jgit:org.eclipse.jgit:5.0.0.201805301535-rc2
 org.slf4j:slf4j-api:1.7.25

--- a/reckon-gradle/gradle/dependency-locks/testCompile.lockfile
+++ b/reckon-gradle/gradle/dependency-locks/testCompile.lockfile
@@ -1,30 +1,3 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.zafarkhaja:java-semver:0.9.0
-com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.1.3
-com.google.guava:guava:25.1-jre
-com.google.j2objc:j2objc-annotations:1.1
-com.googlecode.javaewah:JavaEWAH:1.1.6
-com.jcraft:jsch.agentproxy.core:0.0.9
-com.jcraft:jsch.agentproxy.jsch:0.0.9
-com.jcraft:jsch.agentproxy.pageant:0.0.9
-com.jcraft:jsch.agentproxy.sshagent:0.0.9
-com.jcraft:jsch.agentproxy.usocket-jna:0.0.9
-com.jcraft:jsch.agentproxy.usocket-nc:0.0.9
-com.jcraft:jsch:0.1.54
-com.jcraft:jzlib:1.1.1
-commons-codec:commons-codec:1.9
-commons-logging:commons-logging:1.2
-net.java.dev.jna:jna-platform:4.1.0
-net.java.dev.jna:jna:4.1.0
-org.ajoberstar:grgit:2.2.1
-org.apache.commons:commons-lang3:3.7
-org.apache.httpcomponents:httpclient:4.5.2
-org.apache.httpcomponents:httpcore:4.4.4
-org.checkerframework:checker-qual:2.0.0
-org.codehaus.mojo:animal-sniffer-annotations:1.14
-org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
-org.slf4j:slf4j-api:1.7.25

--- a/reckon-gradle/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/reckon-gradle/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -20,11 +20,10 @@ commons-logging:commons-logging:1.2
 net.java.dev.jna:jna-platform:4.1.0
 net.java.dev.jna:jna:4.1.0
 org.ajoberstar:grgit:2.2.1
-org.apache.commons:commons-lang3:3.7
 org.apache.httpcomponents:httpclient:4.5.2
 org.apache.httpcomponents:httpcore:4.4.4
 org.checkerframework:checker-qual:2.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.14
 org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
-org.slf4j:slf4j-api:1.7.25
+org.eclipse.jgit:org.eclipse.jgit:5.0.0.201805301535-rc2
+org.slf4j:slf4j-api:1.7.2

--- a/reckon-gradle/gradle/dependency-locks/testRuntime.lockfile
+++ b/reckon-gradle/gradle/dependency-locks/testRuntime.lockfile
@@ -1,30 +1,3 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.zafarkhaja:java-semver:0.9.0
-com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.1.3
-com.google.guava:guava:25.1-jre
-com.google.j2objc:j2objc-annotations:1.1
-com.googlecode.javaewah:JavaEWAH:1.1.6
-com.jcraft:jsch.agentproxy.core:0.0.9
-com.jcraft:jsch.agentproxy.jsch:0.0.9
-com.jcraft:jsch.agentproxy.pageant:0.0.9
-com.jcraft:jsch.agentproxy.sshagent:0.0.9
-com.jcraft:jsch.agentproxy.usocket-jna:0.0.9
-com.jcraft:jsch.agentproxy.usocket-nc:0.0.9
-com.jcraft:jsch:0.1.54
-com.jcraft:jzlib:1.1.1
-commons-codec:commons-codec:1.9
-commons-logging:commons-logging:1.2
-net.java.dev.jna:jna-platform:4.1.0
-net.java.dev.jna:jna:4.1.0
-org.ajoberstar:grgit:2.2.1
-org.apache.commons:commons-lang3:3.7
-org.apache.httpcomponents:httpclient:4.5.2
-org.apache.httpcomponents:httpcore:4.4.4
-org.checkerframework:checker-qual:2.0.0
-org.codehaus.mojo:animal-sniffer-annotations:1.14
-org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
-org.slf4j:slf4j-api:1.7.25

--- a/reckon-gradle/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/reckon-gradle/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -26,5 +26,5 @@ org.apache.httpcomponents:httpcore:4.4.4
 org.checkerframework:checker-qual:2.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.14
 org.eclipse.jgit:org.eclipse.jgit.ui:4.11.0.201803080745-r
-org.eclipse.jgit:org.eclipse.jgit:4.11.0.201803080745-r
+org.eclipse.jgit:org.eclipse.jgit:5.0.0.201805301535-rc2
 org.slf4j:slf4j-api:1.7.25


### PR DESCRIPTION
Use latest grgit which is JGit 5 compatible and stop using
now-deprecated methods in Reckoncode.

This fixes #82.