### PR TITLE
Expose tag selector function on Reckon builder and extension

### DIFF
--- a/reckon-core/src/main/java/org/ajoberstar/reckon/core/Reckoner.java
+++ b/reckon-core/src/main/java/org/ajoberstar/reckon/core/Reckoner.java
@@ -159,6 +159,10 @@ public final class Reckoner {
       return this;
     }
 
+    private VcsInventory emptyVcsInventory() {
+      return new VcsInventory(null, false, null, null, null, 0, Collections.emptySet(), Collections.emptySet());
+    }
+
     /**
      * Use the given JGit repository to infer the state of Git.
      *
@@ -167,9 +171,30 @@ public final class Reckoner {
      */
     public Builder git(Repository repo) {
       if (repo == null) {
-        this.inventorySupplier = () -> new VcsInventory(null, false, null, null, null, 0, Collections.emptySet(), Collections.emptySet());
+        this.inventorySupplier = this::emptyVcsInventory;
       } else {
         this.inventorySupplier = new GitInventorySupplier(repo);
+      }
+      return this;
+    }
+
+    /**
+     * Use the given JGit repository to infer the state of Git. Receives a tag selector function to
+     * modify tags before they are parsed.
+     *
+     * @param repo repository that the version should be inferred from
+     * @param tagSelector a function to modify a git tag before its parsed
+     * @return this builder
+     */
+    public Builder git(Repository repo, Function<String, Optional<String>> tagSelector) {
+      if (tagSelector == null) {
+        throw new IllegalArgumentException("Tag selector function needs to be defined");
+      }
+
+      if (repo == null) {
+        this.inventorySupplier = this::emptyVcsInventory;
+      } else {
+        this.inventorySupplier = new GitInventorySupplier(repo, tagSelector);
       }
       return this;
     }

--- a/reckon-gradle/src/main/java/org/ajoberstar/reckon/gradle/ReckonExtension.java
+++ b/reckon-gradle/src/main/java/org/ajoberstar/reckon/gradle/ReckonExtension.java
@@ -1,6 +1,7 @@
 package org.ajoberstar.reckon.gradle;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.ajoberstar.grgit.Grgit;
 import org.ajoberstar.grgit.Repository;
@@ -15,17 +16,22 @@ public class ReckonExtension {
   private static final String SNAPSHOT_PROP = "reckon.snapshot";
 
   private Project project;
+  private Grgit grgit;
   private Reckoner.Builder reckoner;
 
   public ReckonExtension(Project project, Grgit grgit) {
     this.project = project;
+    this.grgit = grgit;
     this.reckoner = Reckoner.builder();
-    org.eclipse.jgit.lib.Repository repo = Optional.ofNullable(grgit)
+    this.reckoner.git(gitRepo());
+  }
+
+  private org.eclipse.jgit.lib.Repository gitRepo() {
+    return Optional.ofNullable(grgit)
         .map(Grgit::getRepository)
         .map(Repository::getJgit)
         .map(Git::getRepository)
         .orElse(null);
-    this.reckoner.git(repo);
   }
 
   @Deprecated
@@ -65,6 +71,11 @@ public class ReckonExtension {
 
       return stageProp.isPresent() ? stageProp : snapshotProp;
     });
+    return this;
+  }
+
+  public ReckonExtension tagSelector(Function<String, Optional<String>> tagSelector) {
+    this.reckoner.git(gitRepo(), tagSelector);
     return this;
   }
 


### PR DESCRIPTION
The use case here is to be able to recognize other non-standard tags, as for example `master-RELEASE-1.0.0`, or `RELEASE-1.0.0`, etc...

This is just a preview to start a discussion, maybe you would like this to be done is some other way.

I have made the simplest possible solution to expose `tagSelector` to the builder and to the Gradle extension.
I understand maybe you don't wish to expose it to the Gradle extension.

There is two other ways I can see a solution for this problem:

* We could instead expose a regex String, and adapt the code of `GitInventorySupplier` to work with a regex pattern

* We could just not expose anything, but write a more inclusive default tag selector. For instance, we could instead of removing just a `v`, remove any non number string from the start of the String until we find the first number...

Let me know what solution you see more fit, and I can change this PR.

Note: I have not looked at the tests yet as I want to wait until you approve the approach before doing that (but I made sure the test still pass).

Thanks.

