### PR TITLE
Add interface to allow Kotlin build scripts to gain access to Version object #137

### DIFF
--- a/reckon-gradle/src/main/java/org/ajoberstar/reckon/gradle/ReckonPlugin.java
+++ b/reckon-gradle/src/main/java/org/ajoberstar/reckon/gradle/ReckonPlugin.java
@@ -41,7 +41,7 @@ public class ReckonPlugin implements Plugin<Project> {
     task.setDescription("Tag version inferred by reckon.");
     task.setGroup("publishing");
     task.onlyIf(t -> {
-      Version version = ((DelayedVersion) project.getVersion()).getVersion();
+      Version version = ((VersionProvider) project.getVersion()).getVersion();
 
       // rebuilds shouldn't trigger a new tag
       boolean alreadyTagged = grgit.getTag().list().stream()
@@ -71,13 +71,14 @@ public class ReckonPlugin implements Plugin<Project> {
     return task;
   }
 
-  private static class DelayedVersion {
+  private static class DelayedVersion implements VersionProvider {
     private final Supplier<Version> reckoner;
 
     public DelayedVersion(Supplier<Version> reckoner) {
       this.reckoner = Suppliers.memoize(reckoner);
     }
 
+    @Override
     public Version getVersion() {
       return reckoner.get();
     }

--- a/reckon-gradle/src/main/java/org/ajoberstar/reckon/gradle/VersionProvider.java
+++ b/reckon-gradle/src/main/java/org/ajoberstar/reckon/gradle/VersionProvider.java
@@ -1,0 +1,11 @@
+package org.ajoberstar.reckon.gradle;
+
+import org.ajoberstar.reckon.core.Version;
+
+/*
+ * Allow Kotlin build scripts to gain access to the Version object without exposing implementation
+ * details/classes as well as other plugins to extend/implement their own version provider
+ */
+public interface VersionProvider {
+  Version getVersion();
+}


### PR DESCRIPTION
- Add the VersionProvider interface to allow Kotlin build scripts to gain access to the Version object and it's methods
- The VersionProvider interface also has the side benefit of allowing other plugins to implement/extend the object
- Add test that validates Kotlin based scripts can now call isFinal on the version object.

Fixes the issue #137 