### PR TITLE
Add support to snapshots in stage mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ There are three types of stages:
 - `<major>` a postive integer incremented when incompatible API changes are made
 - `<minor>` a positive integer incremented when functionality is added while preserving backwards-compatibility
 - `<patch>` a positive integer incremented when fixes are made that preserve backwards-compatibility
-- `<stage>` an alphabetical identifier indicating a level of maturity on the way to a final release. They should make logical sense to a human, but alphabetical order **must** be the indicator of maturity to ensure they sort correctly. (e.g. milestone, rc, snapshot would not make sense because snapshot would sort after rc)
+- `<stage>` an alphabetical identifier indicating a level of maturity on the way to a final release. They should make logical sense to a human, but alphabetical order **must** be the indicator of maturity to ensure they sort correctly. (e.g. alpha, beta, milestone, rc, snapshot, this latter doesn't add the `<num>`)
 - `<num>` a positive integer incremented when a significant release is made
 - `<commits>` a positive integer indicating the number of commits since the last final release was made
 - `<hash or timestamp>` if the repo is clean, an abbreviated commit hash of the current HEAD, otherwise a UTC timestamp

--- a/reckon-core/src/main/java/org/ajoberstar/reckon/core/Reckoner.java
+++ b/reckon-core/src/main/java/org/ajoberstar/reckon/core/Reckoner.java
@@ -67,7 +67,9 @@ public final class Reckoner {
       throw new IllegalStateException("Reckoned target normal version " + reckoned.getNormal() + " has already been released.");
     }
 
-    if (inventory.getBaseVersion().compareTo(reckoned) > 0) {
+    if (inventory.getBaseVersion().getStage().equals(FINAL_STAGE)
+        && reckoned.getStage().get().getName().equals(SNAPSHOT_STAGE)
+        && inventory.getBaseVersion().compareTo(reckoned) > 0) {
       throw new IllegalStateException("Reckoned version " + reckoned + " is (and cannot be) less than base version " + inventory.getBaseVersion());
     }
 
@@ -105,7 +107,7 @@ public final class Reckoner {
         .map(String::toLowerCase)
         .orElse(null);
 
-    if (stage != null && !stages.contains(stage)) {
+    if (stage != null && (!stages.contains(stage) && !stage.equals(SNAPSHOT_STAGE))) {
       String message = String.format("Stage \"%s\" is not one of: %s", stage, stages);
       throw new IllegalArgumentException(message);
     }
@@ -210,7 +212,7 @@ public final class Reckoner {
           .orElseThrow(() -> new IllegalArgumentException("No non-final stages provided."));
 
       if (this.stages.contains(SNAPSHOT_STAGE)) {
-        throw new IllegalArgumentException("Snapshots are not supported in stage mode.");
+        this.defaultStage = SNAPSHOT_STAGE;
       }
 
       return this;

--- a/reckon-core/src/test/groovy/org/ajoberstar/reckon/core/ReckonerTest.groovy
+++ b/reckon-core/src/test/groovy/org/ajoberstar/reckon/core/ReckonerTest.groovy
@@ -11,13 +11,6 @@ class ReckonerTest extends Specification {
   private static final Clock CLOCK = Clock.fixed(Instant.ofEpochSecond(1530724706), ZoneId.of('UTC'))
   private static final String TIMESTAMP = '20180704T171826Z'
 
-  def 'if snapshot provided to stages builder, throw'() {
-    when:
-    Reckoner.builder().stages('snapshot', 'beta', 'final')
-    then:
-    thrown(IllegalArgumentException)
-  }
-
   @Unroll
   def 'stages are lowercased'(String stage) {
     given:


### PR DESCRIPTION
A `snapshot` doesn't have a `<num>` to allow publishing to the Sonatype snapshots repository easily and it has a higher value than an `rc`, but lower than the final one.