### PR TITLE
Instructions for specifying Gradle plugin in Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,21 @@ Reckon can alternately use SNAPSHOT versions instead of the stage concept.
 
 #### Apply the plugin
 
+In `settings.gradle`:
+
+```groovy
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+```
+
+**NB:** `mavenCentral()` must be before `gradlePluginPortal()`.
+
+Then in `build.gradle`:
+
 ```groovy
 plugins {
   id 'org.ajoberstar.reckon' version '<version>'


### PR DESCRIPTION
#176 Update to README with instructions for getting Gradle plugin from Maven Central.