### PR TITLE
Only use parallel version avoidance for significants

### DIFF
--- a/reckon-core/src/main/java/org/ajoberstar/reckon/core/Reckoner.java
+++ b/reckon-core/src/main/java/org/ajoberstar/reckon/core/Reckoner.java
@@ -92,9 +92,10 @@ public final class Reckoner {
     }
 
     var targetNormal = inventory.getBaseNormal().incrementNormal(scope);
+    var probableStage = stageCalc.calculate(inventory, targetNormal);
 
     // if a version's already being developed on a parallel branch we'll skip it
-    if (inventory.getParallelNormals().contains(targetNormal)) {
+    if (inventory.getParallelNormals().contains(targetNormal) && probableStage.isPresent()) {
       if (scope.compareTo(parallelBranchScope) < 0) {
         logger.debug("Skipping {} as it's being developed on a parallel branch. While {} was requested, parallel branches claim a {}, using that instead.", scope, parallelBranchScope);
         targetNormal = targetNormal.incrementNormal(parallelBranchScope);


### PR DESCRIPTION
Only if reckoning a significant version should we try to avoid version numbers tagged on parallel branches. This is in line with our
existing documented axioms (which focused on two TAGGED parallel versions).

What this helps with is feature branches where you aren't intending to make a release, and there's more benefit to having the version logically related to what the history of the branch is, rather than assuming the feature branch will eventually conflict and try to eagerly avoid the existing parallel version.